### PR TITLE
refactor(services): replace any type with Record<string, unknown> 

### DIFF
--- a/lib/services/unified-setup.ts
+++ b/lib/services/unified-setup.ts
@@ -77,7 +77,7 @@ export class UnifiedSetupService {
     userId: string, 
     email: string, 
     authProvider: string, 
-    userMetadata: any = {}
+    userMetadata: Record<string, unknown> = {}
   ): Promise<boolean> {
     const { data, error } = await this.supabase
       .rpc('create_oauth_profile', {
@@ -99,7 +99,7 @@ export class UnifiedSetupService {
   async createEmailProfile(
     userId: string, 
     email: string, 
-    userMetadata: any = {}
+    userMetadata: Record<string, unknown> = {}
   ): Promise<boolean> {
     const { data, error } = await this.supabase
       .rpc('create_email_profile', {


### PR DESCRIPTION
replace any type with Record<string, unknown>  in user metadata

Improve type safety by using a more specific type for user metadata parameters instead of any