### PR TITLE
fix: correct test navigation URL and organization name

### DIFF
--- a/app/tests/page.tsx
+++ b/app/tests/page.tsx
@@ -208,7 +208,7 @@ export default function TestsPage() {
       }
 
       // Navigate to test
-      router.push(`/tests/${testId}/take`);
+      router.push(`/tests/${testId}`);
     } catch {
       toast.error('Failed to start test');
     }

--- a/components/admin/TestManager.tsx
+++ b/components/admin/TestManager.tsx
@@ -2106,7 +2106,7 @@ function TestCertificates({ testId }: { testId: string }) {
                     issued_date: new Date().toLocaleDateString(),
                     category: 'Test Completion',
                     duration: `${selectedAttempt.time_taken_minutes} minutes`,
-                    organization: 'CodeUnia',
+                    organization: 'Codeunia',
                     institution: selectedAttempt.test_registrations?.institution,
                     department: selectedAttempt.registration?.department,
                     experience_level: selectedAttempt.test_registrations?.experience_level


### PR DESCRIPTION
update test navigation URL to remove '/take' suffix fix typo in organization name from 'CodeUnia' to 'Codeunia'