### PR TITLE
fix: Resolve Vercel project linking issues in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -266,8 +266,9 @@ jobs:
         run: |
           # Remove any existing .vercel directory to avoid conflicts
           rm -rf .vercel
-          # Link project using environment variables
-          vercel link --token ${{ secrets.VERCEL_TOKEN }} --yes
+          # Create .vercel directory with project configuration
+          mkdir -p .vercel
+          echo '{"orgId":"${{ secrets.VERCEL_ORG_ID }}","projectId":"${{ secrets.VERCEL_PROJECT_ID }}"}' > .vercel/project.json
           # Deploy to staging
           vercel --token ${{ secrets.VERCEL_TOKEN }} --yes
         env:
@@ -303,8 +304,9 @@ jobs:
         run: |
           # Remove any existing .vercel directory to avoid conflicts
           rm -rf .vercel
-          # Link project using environment variables
-          vercel link --token ${{ secrets.VERCEL_TOKEN }} --yes
+          # Create .vercel directory with project configuration
+          mkdir -p .vercel
+          echo '{"orgId":"${{ secrets.VERCEL_ORG_ID }}","projectId":"${{ secrets.VERCEL_PROJECT_ID }}"}' > .vercel/project.json
           # Deploy to production
           vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --yes
         env:
@@ -336,8 +338,9 @@ jobs:
 
       - name: Rollback deployment
         run: |
-          # Link project using environment variables
-          vercel link --token ${{ secrets.VERCEL_TOKEN }} --yes
+          # Create .vercel directory with project configuration
+          mkdir -p .vercel
+          echo '{"orgId":"${{ secrets.VERCEL_ORG_ID }}","projectId":"${{ secrets.VERCEL_PROJECT_ID }}"}' > .vercel/project.json
           # Perform rollback
           vercel rollback --token ${{ secrets.VERCEL_TOKEN }} --yes
         env:

--- a/scripts/test-ci-local.sh
+++ b/scripts/test-ci-local.sh
@@ -97,9 +97,10 @@ test_vercel_commands() {
     print_status "Vercel CLI version:"
     vercel --version
     
-    # Test linking (this will fail with dummy secrets, but we can see the command structure)
-    print_status "Testing Vercel link command structure..."
-    echo "vercel link --token \$VERCEL_TOKEN --yes"
+    # Test project configuration creation
+    print_status "Testing Vercel project configuration creation..."
+    echo "mkdir -p .vercel"
+    echo "echo '{\"orgId\":\"\$VERCEL_ORG_ID\",\"projectId\":\"\$VERCEL_PROJECT_ID\"}' > .vercel/project.json"
     
     # Test deployment command structure
     print_status "Testing Vercel deployment command structure..."


### PR DESCRIPTION
- Replace failing 'vercel link' command with manual .vercel directory creation
- Create .vercel/project.json with orgId and projectId from environment variables
- Update staging, production, and rollback deployment steps
- Update local testing scripts and documentation
- Fixes 'Could not retrieve Project Settings' error

This approach is more reliable than the 'vercel link' command which was failing due to project settings retrieval issues.