### PR TITLE
fix: Use direct --scope flag for Vercel deployment instead of .vercel…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -266,11 +266,8 @@ jobs:
         run: |
           # Remove any existing .vercel directory to avoid conflicts
           rm -rf .vercel
-          # Create .vercel directory with project configuration
-          mkdir -p .vercel
-          echo '{"orgId":"${{ secrets.VERCEL_ORG_ID }}","projectId":"${{ secrets.VERCEL_PROJECT_ID }}"}' > .vercel/project.json
-          # Deploy to staging
-          vercel --token ${{ secrets.VERCEL_TOKEN }} --yes
+          # Deploy directly using scope and project flags
+          vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --yes
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -304,11 +301,8 @@ jobs:
         run: |
           # Remove any existing .vercel directory to avoid conflicts
           rm -rf .vercel
-          # Create .vercel directory with project configuration
-          mkdir -p .vercel
-          echo '{"orgId":"${{ secrets.VERCEL_ORG_ID }}","projectId":"${{ secrets.VERCEL_PROJECT_ID }}"}' > .vercel/project.json
-          # Deploy to production
-          vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --yes
+          # Deploy directly using scope and project flags
+          vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --yes
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -338,11 +332,10 @@ jobs:
 
       - name: Rollback deployment
         run: |
-          # Create .vercel directory with project configuration
-          mkdir -p .vercel
-          echo '{"orgId":"${{ secrets.VERCEL_ORG_ID }}","projectId":"${{ secrets.VERCEL_PROJECT_ID }}"}' > .vercel/project.json
-          # Perform rollback
-          vercel rollback --token ${{ secrets.VERCEL_TOKEN }} --yes
+          # Remove any existing .vercel directory to avoid conflicts
+          rm -rf .vercel
+          # Perform rollback using scope flag
+          vercel rollback --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --yes
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/scripts/test-ci-local.sh
+++ b/scripts/test-ci-local.sh
@@ -97,15 +97,10 @@ test_vercel_commands() {
     print_status "Vercel CLI version:"
     vercel --version
     
-    # Test project configuration creation
-    print_status "Testing Vercel project configuration creation..."
-    echo "mkdir -p .vercel"
-    echo "echo '{\"orgId\":\"\$VERCEL_ORG_ID\",\"projectId\":\"\$VERCEL_PROJECT_ID\"}' > .vercel/project.json"
-    
-    # Test deployment command structure
-    print_status "Testing Vercel deployment command structure..."
-    echo "vercel --token \$VERCEL_TOKEN --yes"
-    echo "vercel --prod --token \$VERCEL_TOKEN --yes"
+    # Test direct deployment with scope flag
+    print_status "Testing Vercel direct deployment with scope flag..."
+    echo "vercel --token \$VERCEL_TOKEN --scope \$VERCEL_ORG_ID --yes"
+    echo "vercel --prod --token \$VERCEL_TOKEN --scope \$VERCEL_ORG_ID --yes"
     
     print_success "Vercel command testing completed!"
 }


### PR DESCRIPTION
… directory

- Replace .vercel directory creation with direct --scope flag usage
- Use 'vercel --scope $ORG_ID' instead of creating project.json
- This avoids the 'Could not retrieve Project Settings' error
- Update staging, production, and rollback deployment steps
- Update local testing scripts and documentation

The --scope flag directly specifies the organization/team without requiring project linking or .vercel directory configuration.