### PR TITLE
fix: Add --project flag to Vercel deployment commands

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -267,7 +267,7 @@ jobs:
           # Remove any existing .vercel directory to avoid conflicts
           rm -rf .vercel
           # Deploy directly using scope and project flags
-          vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --yes
+          vercel --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --project ${{ secrets.VERCEL_PROJECT_ID }} --yes
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -302,7 +302,7 @@ jobs:
           # Remove any existing .vercel directory to avoid conflicts
           rm -rf .vercel
           # Deploy directly using scope and project flags
-          vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --yes
+          vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --scope ${{ secrets.VERCEL_ORG_ID }} --project ${{ secrets.VERCEL_PROJECT_ID }} --yes
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
- Add --project ${{ secrets.VERCEL_PROJECT_ID }} flag to both staging and production deployment jobs
- Fixes 'Could not retrieve Project Settings' error in CI/CD pipeline
- Ensures Vercel CLI can identify the correct project without .vercel/project.json