### PR TITLE
fix: Use vercel build instead of npm run build for proper prebuilt de…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -299,8 +299,7 @@ jobs:
         run: npm ci
 
       - name: Build for Vercel
-        run: |
-          npm run build
+        run: vercel build --token ${{ secrets.VERCEL_TOKEN }}
         env:
           NODE_ENV: production
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -378,8 +377,7 @@ jobs:
         run: npm ci
 
       - name: Build for Vercel
-        run: |
-          npm run build
+        run: vercel build --token ${{ secrets.VERCEL_TOKEN }}
         env:
           NODE_ENV: production
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}


### PR DESCRIPTION
…ployment

🔧 Vercel Build Fix:
- Replace 'npm run build' with 'vercel build'
- Creates proper .vercel/output/ directory structure
- Fixes --prebuilt deployment errors
- Enables faster, optimized Vercel deployments

✅ Benefits:
- Faster deployments (no double building)
- Proper Vercel optimization
- Correct build artifacts (.vercel/output/ vs .next/)
- Resolves missing static assets and MIME type issues