### PR TITLE
fix: Add vercel pull step before build to resolve project settings error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -298,6 +298,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Pull Vercel Project Settings
+        run: vercel pull --yes --token ${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
       - name: Build for Vercel
         run: vercel build --token ${{ secrets.VERCEL_TOKEN }}
         env:
@@ -375,6 +381,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Pull Vercel Project Settings
+        run: vercel pull --yes --token ${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build for Vercel
         run: vercel build --token ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
- Add 'Pull Vercel Project Settings' step before 'Build for Vercel' in both staging and production jobs
- This resolves the 'No Project Settings found locally' error when running vercel build
- Ensures proper project configuration is available before building