### PR TITLE
fix: Add --prod flag to vercel build for production environment match

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -389,7 +389,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build for Vercel
-        run: vercel build --token ${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token ${{ secrets.VERCEL_TOKEN }}
         env:
           NODE_ENV: production
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}


### PR DESCRIPTION
- Add --prod flag to 'Build for Vercel' step in production job
- This resolves the 'prebuilt environment mismatch' error
- Ensures build target (production) matches deployment target (--prod)
- Staging job correctly uses preview environment (no --prod flag)