### PR TITLE
fix: Resolve Lighthouse CI build and GitHub token issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -594,6 +594,7 @@ jobs:
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           LHCI_TOKEN: ${{ secrets.LHCI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload performance results
         uses: actions/upload-artifact@v4

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -9,7 +9,7 @@ module.exports = {
         'http://localhost:3000/auth/signin',
         'http://localhost:3000/protected/dashboard'
       ],
-      startServerCommand: 'npm run start',
+      startServerCommand: 'npm run build && npm run start',
       startServerReadyPattern: 'ready on',
       startServerReadyTimeout: 30000,
       numberOfRuns: 3,


### PR DESCRIPTION
🔧 Additional fixes:
1. ✅ Lighthouse CI build issue - Updated startServerCommand to include 'npm run build && npm run start'
2. ✅ GitHub token issue - Added GITHUB_TOKEN environment variable for Lighthouse CI
3. ✅ Build sequence - Ensures Next.js app is built before starting for Lighthouse CI

🎯 Root cause fixes:
- Lighthouse CI was trying to start server without building first
- Missing GITHUB_TOKEN for Lighthouse CI GitHub integration
- Build and start sequence now properly configured

This should resolve both the 'Could not find production build' and 'GitHub token not set' errors.