### PR TITLE
fix: Improve Lighthouse CI server startup reliability

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -10,11 +10,11 @@ module.exports = {
         'http://localhost:3000/protected/dashboard'
       ],
       startServerCommand: 'npm run build && npm run start',
-      startServerReadyPattern: 'ready on',
-      startServerReadyTimeout: 30000,
-      numberOfRuns: 3,
+      startServerReadyPattern: 'Ready in|ready on|Local:',
+      startServerReadyTimeout: 120000,
+      numberOfRuns: 1,
       settings: {
-        chromeFlags: '--no-sandbox --disable-dev-shm-usage',
+        chromeFlags: '--no-sandbox --disable-dev-shm-usage --disable-gpu --disable-web-security',
         preset: 'desktop'
       }
     },

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -14,7 +14,7 @@ module.exports = {
       startServerReadyTimeout: 120000,
       numberOfRuns: 1,
       settings: {
-        chromeFlags: '--no-sandbox --disable-dev-shm-usage --disable-gpu --disable-web-security',
+        chromeFlags: '--no-sandbox --disable-dev-shm-usage --disable-gpu',
         preset: 'desktop'
       }
     },


### PR DESCRIPTION
🔧 Lighthouse CI improvements:
1. ✅ Extended server ready timeout from 30s to 120s (2 minutes)
2. ✅ Enhanced ready pattern to match multiple Next.js startup messages
3. ✅ Added additional Chrome flags for CI environment stability
4. ✅ Reduced number of runs from 3 to 1 for faster CI execution
5. ✅ Better error handling for server startup issues

🎯 Root cause fixes:
- Server timeout issues in CI environment
- Chrome interstitial errors due to server not being ready
- Improved pattern matching for Next.js startup messages

This should resolve the 'Chrome prevented page load with an interstitial' errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved server readiness detection for Lighthouse audits to handle multiple startup messages.

- Chores
  - Extended server startup timeout for audits to reduce flakes.
  - Reduced Lighthouse audit runs from 3 to 1 to speed up execution.
  - Expanded Chrome launch flags (including GPU and web security adjustments) for better environment compatibility.

- Tests
  - Stabilized Lighthouse audit configuration to produce more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->