### PR TITLE
Fix CSP violations: Allow inline scripts/styles and Cloudflare Insights

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -73,7 +73,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://vercel.live https://va.vercel-scripts.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co https://*.vercel.app wss://*.supabase.co; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://va.vercel-scripts.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co https://*.vercel.app wss://*.supabase.co; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
         }
       ]
     }


### PR DESCRIPTION
- Added 'unsafe-inline' to script-src for Next.js inline scripts
- Added 'unsafe-eval' to script-src for dynamic script evaluation
- Added 'unsafe-inline' to style-src for Google Fonts and inline styles
- Added https://static.cloudflareinsights.com to script-src for Cloudflare Analytics
- This resolves the 35+ CSP violations preventing site from loading properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled Cloudflare Insights analytics to load properly.
- Bug Fixes
  - Resolved issues where scripts and styles were blocked, improving page interactivity and styling in some environments.
- Chores
  - Updated site security policy to allow required scripts and styles while maintaining existing protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->